### PR TITLE
Bump notebookscripter support to version 6.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "NotebookScripter" %}
-{% set version = "5.1.0" %}
+{% set version = "6.0.0" %}
 
 package:
   name: '{{ name|lower }}'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 71ba29f31819a0e440f72881f49c065dce3d0fcd98b80b0325f27c4f42c9cae3
+  sha256: c4acc888b160e4f7dc46bfb4f4c700101e5bae4f8a211021ccb4f1bd139fd5c7
 
 build:
   noarch: python


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a fork of the feedstock to propose changes
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

HUGE APOLOGIES for incorrectly updating this repository by pushing directly to the master branch!  That was a mistake in protocol on my part and will not do that again!  I reverted the change made directly to master -- and am re-proposing this change in a PR which bump's package version to 6.0.0.
